### PR TITLE
Backport bugfixes from CloudCompare

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ csf_module = Extension(
 
 setup(
     name="CSF_3DFin",
-    version="1.1.5",
+    version="1.2.0",
     author="Jianbo Qi",
     url="http://ramm.bnu.edu.cn/projects/CSF/",
     long_description=readme_content,

--- a/src/CSF.cpp
+++ b/src/CSF.cpp
@@ -153,7 +153,7 @@ Cloth CSF::do_cloth() {
     double gravity    = 0.2;
 
     std::cout << "[" << this->index << "] Simulating..." << std::endl;
-    cloth.addForce(Vec3(0, -gravity, 0) * time_step2);
+    cloth.addForce(Vec3(0, -gravity, 0) * time_step2); // pre multiply the force by the time step to speed up the simulation
 
     // boost::progress_display pd(params.interations);
     for (int i = 0; i < params.interations; i++) {

--- a/src/Cloth.cpp
+++ b/src/Cloth.cpp
@@ -104,7 +104,7 @@ double Cloth::timeStep() {
     }
 
     #ifdef CSF_USE_OPENMP
-    #pragma omp parallel for
+    //#pragma omp parallel for => This is not thread safe due to call to offsetPos on neighbors
     #endif
     for (int j = 0; j < particleCount; j++) {
         particles[j].satisfyConstraintSelf(constraint_iterations);

--- a/src/Cloth.cpp
+++ b/src/Cloth.cpp
@@ -52,7 +52,7 @@ Cloth::Cloth(const Vec3& _origin_pos,
                      origin_pos.f[2] + j *step_y);
 
             // insert particle in column i at j'th row
-            particles[j * num_particles_width + i]       = Particle(pos, time_step2);
+            particles[j * num_particles_width + i]       = Particle(pos /*, time_step2*/); // time_step2 is unused
             particles[j * num_particles_width + i].pos_x = i;
             particles[j * num_particles_width + i].pos_y = j;
         }

--- a/src/Particle.cpp
+++ b/src/Particle.cpp
@@ -24,7 +24,7 @@
 void Particle::timeStep() {
     if (movable) {
         Vec3 temp = pos;
-        pos = pos + (pos - old_pos) * (1.0 - DAMPING) + acceleration * time_step2;
+        pos = pos + (pos - old_pos) * (1.0 - DAMPING) + acceleration; /*acceleration is pre multiplied by time_step2*/;
         old_pos = temp;
     }
 }

--- a/src/Particle.h
+++ b/src/Particle.h
@@ -101,7 +101,7 @@ public:
     Particle() :
       movable(true),
       //mass(1),
-      acceleration(Vec3(0, 0, 0)),
+      // acceleration(Vec3(0, 0, 0)),
       accumulated_normal(Vec3(0, 0, 0)),
       pos(Vec3(0, 0, 0)),
       old_pos(Vec3(0, 0, 0)) {
@@ -119,8 +119,10 @@ public:
         return movable;
     }
 
+    //TODO: acceleration is a constant and should be either initialized by a const ref in the constructor
+    // or by addind a ref to the Cloth object and using it to get the acceleration.
     void addForce(Vec3 f) {
-        acceleration += f; // mass was here for correctness. it's always 1 in this example;
+        acceleration = f; // mass was here for correctness. it's always 1 in this example;  
     }
 
     /* This is one of the important methods, where the time is
@@ -134,10 +136,6 @@ public:
 
     Vec3 getPosCopy() {
         return pos;
-    }
-
-    void resetAcceleration() {
-        acceleration = Vec3(0, 0, 0);
     }
 
     void offsetPos(const Vec3 v) {

--- a/src/Particle.h
+++ b/src/Particle.h
@@ -81,12 +81,12 @@ public:
 
 public:
 
-    Particle(Vec3 pos, double time_step) :
+    Particle(Vec3 pos/*, double time_step*/): 
         movable(true),
         //mass(1),
         acceleration(Vec3(0, 0, 0)),
         accumulated_normal(Vec3(0, 0, 0)),
-        time_step2(time_step),
+        // time_step2(time_step), already used into the call of Cloth::addForce(), at initialization
         pos(pos),
         old_pos(pos) {
         isVisited          = false;
@@ -120,7 +120,7 @@ public:
     }
 
     void addForce(Vec3 f) {
-        acceleration += f // / mass; mass is here for corect always 1 in this example;
+        acceleration += f; // mass was here for correctness. it's always 1 in this example;
     }
 
     /* This is one of the important methods, where the time is

--- a/src/Particle.h
+++ b/src/Particle.h
@@ -52,7 +52,7 @@ class Particle {
 private:
 
     bool movable;            // can the particle move or not ? used to pin parts of the cloth
-    double mass;             // the mass of the particle (is always 1 in this example)
+    //double mass;             // the mass of the particle (is always 1 in this example)
     Vec3 acceleration;       // a vector representing the current acceleration of the particle
     Vec3 accumulated_normal; // an accumulated normal (i.e. non normalized), used for OpenGL soft shading
     double time_step2;
@@ -83,7 +83,7 @@ public:
 
     Particle(Vec3 pos, double time_step) :
         movable(true),
-        mass(1),
+        //mass(1),
         acceleration(Vec3(0, 0, 0)),
         accumulated_normal(Vec3(0, 0, 0)),
         time_step2(time_step),
@@ -100,7 +100,7 @@ public:
 
     Particle() :
       movable(true),
-      mass(1),
+      //mass(1),
       acceleration(Vec3(0, 0, 0)),
       accumulated_normal(Vec3(0, 0, 0)),
       pos(Vec3(0, 0, 0)),
@@ -120,7 +120,7 @@ public:
     }
 
     void addForce(Vec3 f) {
-        acceleration += f / mass;
+        acceleration += f // / mass; mass is here for corect always 1 in this example;
     }
 
     /* This is one of the important methods, where the time is


### PR DESCRIPTION
Backport bugfixes from https://github.com/CloudCompare/CloudCompare/pull/1965

Most notably, this fix a race condition in the simulation process that leads to inconsistencies in the results and a non deterministic behavior.